### PR TITLE
ci: add GitHub Actions workflow for backend tests and frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel superseded runs for the same ref (e.g. new push to an open PR)
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend — tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      NODE_ENV: test
+      # Tests need a JWT secret to sign tokens; there is no .env in CI.
+      JWT_SECRET: ci-test-secret
+      # Cache the mongodb-memory-server binary outside node_modules so it
+      # survives `npm ci` (which wipes node_modules) and across runs.
+      MONGOMS_DOWNLOAD_DIR: ${{ github.workspace }}/.cache/mongodb-binaries
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Cache MongoDB binary
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.cache/mongodb-binaries
+          key: mongodb-binaries-${{ runner.os }}
+
+      - run: npm ci
+
+      - run: npm test
+
+  frontend:
+    name: Frontend — build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front-end-react
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: front-end-react/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run build

--- a/backend/jest.config.cjs
+++ b/backend/jest.config.cjs
@@ -7,5 +7,6 @@ module.exports = {
   resetMocks: true,
   restoreMocks: true,
   setupFiles: ['<rootDir>/tests/setup/env.js'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup/jest.setup.js'],
   testTimeout: 60000,
 };


### PR DESCRIPTION
## Summary

- Adds a CI workflow that runs on every PR to `main` and on every push to `main`.
- **Backend** job: `npm ci` + `npm test` (jest integration suite). Injects `JWT_SECRET` and `NODE_ENV=test`, and caches the `mongodb-memory-server` binary outside `node_modules` so `npm ci` doesn't trigger a ~100MB re-download each run.
- **Frontend** job: `npm ci` + `npm run build` (vite).

This is the project's first CI. Until now there was no automated safety net, so dependency bumps and code changes merged without tests or build ever running.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | New CI workflow: backend tests + frontend build, run in parallel |

## Test plan

- [x] Frontend build verified locally (`npm run build` — 881 modules, success)
- [x] Backend + frontend dependencies install cleanly (`npm ci`)
- [ ] Backend jest suite runs green on the runner (verified here via this PR — `mongodb-memory-server` replset starts on GitHub's Ubuntu runners, unlike the local WSL2 sandbox)

## Notes

- **Node 20** (LTS) — most battle-tested with `mongodb-memory-server`. Easy to bump if you want to match local Node 24.
- **Lint is intentionally not part of CI.** The `lint` scripts reference `eslint`, but it is not in `devDependencies` of either package (and there's an orphaned root `.eslintrc.json`). Wiring up lint properly is a separate follow-up.
